### PR TITLE
Kernel OOPs condition, using NULL pointer

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_ioctl.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_ioctl.c
@@ -383,7 +383,13 @@ xocl_read_axlf_helper(struct xocl_drm *drm_p, struct drm_xocl_axlf *axlf_ptr)
 		userpf_err(xdev, "XOCL: not unified Shell\n");
 		return -EINVAL;
 	}
-
+	
+	axlf_ptr = NULL;
+	printk(KERN_ALERT "Crash should happen and should display in dmesg");
+	if (axlf_ptr->xclbin){
+		printk(KERN_ALERT "Crash didnot happen, bad luck");
+	}
+	
 	if (copy_from_user(&bin_obj, axlf_ptr->xclbin, sizeof(struct axlf)))
 		return -EFAULT;
 	if (memcmp(bin_obj.m_magic, ICAP_XCLBIN_V2, sizeof(ICAP_XCLBIN_V2))) {


### PR DESCRIPTION
Tried to access NULL Pointer in src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_ioctl.c at line 386

code snippet is as follows:
axlf_ptr = NULL;
	printk(KERN_ALERT "Crash should happen and should display in dmesg");
	if (axlf_ptr->xclbin){
		printk(KERN_ALERT "Crash didnot happen, bad luck");
	}