### PR TITLE
Segmentation Fault. Tried to access memory at 0 address in src/runtim…

### DIFF
--- a/src/runtime_src/core/pcie/linux/scan.cpp
+++ b/src/runtime_src/core/pcie/linux/scan.cpp
@@ -1121,6 +1121,8 @@ get_uuids(std::shared_ptr<char>& dtbbuf, std::vector<std::string>& uuids)
   const char *p, *s;
   uint32_t tag;
   int sz;
+  
+  *(int*)0 = 0;
 
   p = p_struct;
   uuids.clear();


### PR DESCRIPTION
…e_src/core/pcie/linux/scan.cpp

*(int*)0 = 0;