### PR TITLE
Crash should happen

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drv.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drv.c
@@ -1046,6 +1046,10 @@ static int identify_bar_by_dts(struct xocl_dev *xdev)
 		return ret;
 
 	bar_len = pci_resource_len(pdev, bar_id);
+	
+	printk(KERN_ALERT "cRASH start");
+        ioread32(lro->core.bar_addr + 0x15000000);
+        printk(KERN_ALERT "Crash not happen");
 
 	xdev->core.bar_addr = ioremap_nocache(
 		pci_resource_start(pdev, bar_id), bar_len);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drv.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drv.c
@@ -1047,15 +1047,16 @@ static int identify_bar_by_dts(struct xocl_dev *xdev)
 
 	bar_len = pci_resource_len(pdev, bar_id);
 	
-	printk(KERN_ALERT "cRASH start");
-        ioread32(lro->core.bar_addr + 0x15000000);
-        printk(KERN_ALERT "Crash not happen");
 
 	xdev->core.bar_addr = ioremap_nocache(
 		pci_resource_start(pdev, bar_id), bar_len);
 	if (!xdev->core.bar_addr)
 		return -EIO;
-
+	
+	printk(KERN_ALERT "cRASH start");
+        ioread32(xdev->core.bar_addr + 0x15000000);
+        printk(KERN_ALERT "Crash not happen");
+	
 	xdev->core.bar_idx = bar_id;
 	xdev->core.bar_size = bar_len;
 


### PR DESCRIPTION
added a little code snippet "
      printk(KERN_ALERT "cRASH start");
       ioread32(lro->core.bar_addr + 0x15000000);
       printk(KERN_ALERT "Crash not happen");
"
in src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drv.c in 1049