### PR TITLE
XRT BUILD FAIL CASE

### DIFF
--- a/src/runtime_src/core/pcie/linux/shim.cpp
+++ b/src/runtime_src/core/pcie/linux/shim.cpp
@@ -192,7 +192,7 @@ private:
 
 	    i++;
             bufCnt--;
-            byteCnt -= qio.len;
+            byteCnt -= qio.len
             reqList.pop_front();
         }
 


### PR DESCRIPTION
Removed a semicolon from src/runtime_src/core/pcie/linux/shim.cpp