### PR TITLE
Driver build fail case

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/cu.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/cu.c
@@ -81,7 +81,7 @@ poll_interval_show(struct device *dev, struct device_attribute *attr, char *buf)
 	struct platform_device *pdev = to_platform_device(dev);
 	struct xocl_cu *cu = platform_get_drvdata(pdev);
 
-	return sprintf(buf, "%d\n", cu->base.interval_min);
+	return sprintf(buf, "%d\n", cu->base.interval_min)
 }
 
 static ssize_t


### PR DESCRIPTION
Removed a semicolon in one of the driver programs, src/runtime_src/core/pcie/driver/linux/xocl/subdev/cu.c