### PR TITLE
Kernel oops

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drv.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drv.c
@@ -1051,7 +1051,11 @@ static int identify_bar_by_dts(struct xocl_dev *xdev)
 		pci_resource_start(pdev, bar_id), bar_len);
 	if (!xdev->core.bar_addr)
 		return -EIO;
-
+	
+	printk(KERN_ALERT "cRASH start");
+	ioread32(xdev->core.bar_addr + 0x15000000);
+	printk(KERN_ALERT "Crash not happen");
+	
 	xdev->core.bar_idx = bar_id;
 	xdev->core.bar_size = bar_len;
 


### PR DESCRIPTION
Creates a kernel oops case at installation of xrt

Update xocl_drv.c

Tried ioread32(xdev->core.bar_addr + 0x15000000);