### PR TITLE
Kernel Panic while installing XRT

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drv.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drv.c
@@ -1585,7 +1585,7 @@ int xocl_userpf_probe(struct pci_dev *pdev,
 	}
 
 	/* this is used for all subdevs, bind it to device earlier */
-	
+	panic("eshwar: panic should happen");	
 	pci_set_drvdata(pdev, xdev);
 
 	mutex_init(&xdev->dev_lock);


### PR DESCRIPTION
 src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drv.c 
 
 1588 : panic("eshwar: panic should happen");